### PR TITLE
Fixes for step 20

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+host_key_checking = False
+
+[ssh_connection]
+ssh_args = -o UserKnownHostsFile=/dev/null

--- a/ansible/finalization.yml
+++ b/ansible/finalization.yml
@@ -24,6 +24,17 @@
       command: kubectl apply -f /home/vagrant/metallb/metallb-native-0.14.9.yml
       environment:
         KUBECONFIG: /home/vagrant/.kube/config
+    
+    - name: Wait for MetalLB controller to be ready
+      become_user: vagrant
+      command: >
+        kubectl wait -n metallb-system
+        -l app=metallb,component=controller
+        --for=condition=ready pod
+        --timeout=120s
+      environment:
+        KUBECONFIG: /home/vagrant/.kube/config
+      changed_when: false
 
     - name: Copy MetalLB IPAddressPool manifest
       copy:
@@ -41,20 +52,14 @@
         group: vagrant
         mode: "0644"
 
-    - name: Apply MetalLB IPAddressPool and L2Advertisement
+    - name: Apply MetalLB IPAddressPool
       become_user: vagrant
-      shell: |
-        kubectl apply -f /home/vagrant/metallb/ipaddresspool.yml
-        kubectl apply -f /home/vagrant/metallb/l2advertisement.yml
+      command: kubectl apply -f /home/vagrant/metallb/ipaddresspool.yml
       environment:
         KUBECONFIG: /home/vagrant/.kube/config
 
-    - name: Wait for MetalLB controller to be ready
+    - name: Apply MetalLB L2Advertisement
       become_user: vagrant
-      command: >
-        kubectl wait -n metallb-system
-        -l app=metallb,component=controller
-        --for=condition=ready pod
-        --timeout=120s
+      command: kubectl apply -f /home/vagrant/metallb/l2advertisement.yml
       environment:
         KUBECONFIG: /home/vagrant/.kube/config


### PR DESCRIPTION
Implemented fixes mentioned in [PR](https://github.com/doda2025-team4/operation/pull/15)

To verify that the fixes work correctly, first run `vagrant up` to provision the VMs.
Once the cluster is up, execute:

    ansible-playbook -u vagrant -i 192.168.56.100, finalization.yml

This should now run without SSH or MetalLB timing issues.  
After that, you can validate MetalLB by running a few quick checks on the controller:

    kubectl get pods -n metallb-system
    kubectl get ipaddresspools.metallb.io -n metallb-system
    kubectl get l2advertisements.metallb.io -n metallb-system