### PR TITLE
fix: Enable ntp.

### DIFF
--- a/ansible/general.yml
+++ b/ansible/general.yml
@@ -132,3 +132,14 @@
         name: kubelet
         state: started
         enabled: yes
+
+    # Fix ntp alert
+    - name: Set ntp
+      ansible.builtin.command: timedatectl set-ntp true
+    
+    - name: Enable ntp
+      ansible.builtin.service:
+        name: systemd-timesyncd
+        state: started
+        enabled: yes
+


### PR DESCRIPTION
I have not been able to test if I truly don't receive an email anymore, because I haven't been able to get the emails working since the new secret branch was merged. However, the alertmanager page doesn't show the alert anymore, so I think the problem is resolved. 