### PR TITLE
Alert secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,12 +267,12 @@ Once you have your Kubernetes cluster ready (either Vagrant or Minikube), procee
 3. **Create the SMTP password secret:**
    ```bash
    kubectl create namespace doda
-   kubectl create secret generic alertmanager-smtp --from-literal=SMTP_PASSWORD=<your-password> -n doda
+   kubectl -n doda create secret generic alertmanager-smtp --from-literal=SMTP_PASSWORD="ybsuczpfonhkunqy"
    ```
 
     Alternative option: let Helm **generate the Secret** by setting `smtpSecret.create=true` and providing the password at install/upgrade by adding the following to the `helm install` command:
     ```bash
-    --set smtpSecret.create=true --set smtpSecret.smtpPassword='<PASSWORD>'`
+    --set smtpSecret.create=true --set smtpSecret.smtpPassword='ybsuczpfonhkunqy`
     ```
 
 4. **Enable Istio sidecar injection for the namespace:**

--- a/README.md
+++ b/README.md
@@ -244,23 +244,6 @@ put the absolute path to your kubeconfig file in place of YOUR_PATH
    export KUBECONFIG=YOUR_PATH
    ```
 
-3. **Create the SMTP password secret:**
-   ```bash
-   kubectl create namespace doda
-   kubectl create secret generic alertmanager-smtp --from-literal=SMTP_PASSWORD=<your-password> -n doda
-   ```
-
-4. **Enable Istio sidecar injection for the namespace:**
-   ```bash
-   kubectl label namespace doda istio-injection=enabled --overwrite
-   ```
-
-5. **Install the Helm chart:**
-   ```bash
-   cd helm_chart
-   helm dependency update .
-   helm install sms-app . -n doda
-   ```
 
 ##### Option 2: Deploy to Minikube
 
@@ -279,11 +262,18 @@ put the absolute path to your kubeconfig file in place of YOUR_PATH
    cd ..
    ```
 
+Once you have your Kubernetes cluster ready (either Vagrant or Minikube), proceed with the following steps to deploy the application:
+
 3. **Create the SMTP password secret:**
    ```bash
    kubectl create namespace doda
    kubectl create secret generic alertmanager-smtp --from-literal=SMTP_PASSWORD=<your-password> -n doda
    ```
+
+    Alternative option: let Helm **generate the Secret** by setting `smtpSecret.create=true` and providing the password at install/upgrade by adding the following to the `helm install` command:
+    ```bash
+    --set smtpSecret.create=true --set smtpSecret.smtpPassword='<PASSWORD>'`
+    ```
 
 4. **Enable Istio sidecar injection for the namespace:**
    ```bash
@@ -296,8 +286,6 @@ put the absolute path to your kubeconfig file in place of YOUR_PATH
    helm dependency update .
    helm install sms-app . -n doda
    ```
-
-
 #### Prometheus
 - **Custom Prometheus Metrics**  
   App service exposes metrics at `/metrics` endpoint. Metrics are defined in in `app/src/main/java/com/team04/app/MetricsConfig.java`: `sms_active_requests` (Gauge), `sms_predictions_total` (Counter), `sms_prediction_latency` (Histogram).  

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Once you have your Kubernetes cluster ready (either Vagrant or Minikube), procee
 
     Alternative option: let Helm **generate the Secret** by setting `smtpSecret.create=true` and providing the password at install/upgrade by adding the following to the `helm install` command:
     ```bash
-    --set smtpSecret.create=true --set smtpSecret.smtpPassword='ybsuczpfonhkunqy`
+    --set smtpSecret.create=true --set smtpSecret.smtpPassword='ybsuczpfonhkunqy'
     ```
 
 4. **Enable Istio sidecar injection for the namespace:**

--- a/helm_chart/templates/alertmanager-smtp-secret.yml
+++ b/helm_chart/templates/alertmanager-smtp-secret.yml
@@ -1,0 +1,10 @@
+{{- if .Values.smtpSecret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.smtpSecret.name | quote }}
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  SMTP_PASSWORD: {{ required "smtpSecret.smtpPassword is required when not using existing secret" .Values.smtpSecret.smtpPassword | quote }}
+{{- end }}

--- a/helm_chart/templates/alertmanagerconfig.yml
+++ b/helm_chart/templates/alertmanagerconfig.yml
@@ -1,0 +1,34 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.alertmanager.enabled .Values.alerting.enabled }}
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: {{ .Values.alerting.configName | default "email-config" | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    alertmanagerConfig: sms-app
+spec:
+  route:
+    receiver: "null"
+    groupBy: {{ toJson .Values.alerting.route.groupBy }}
+    groupWait: {{ .Values.alerting.route.groupWait }}
+    groupInterval: {{ .Values.alerting.route.groupInterval }}
+    repeatInterval: {{ .Values.alerting.route.repeatInterval }}
+    routes:
+      - receiver: email-alert
+        matchers:
+          - name: namespace
+            matchType: "="
+            value: {{ .Release.Namespace | quote }}
+  receivers:
+    - name: "null"
+    - name: email-alert
+      emailConfigs:
+        - to: {{ .Values.alerting.email.to | quote }}
+          from: {{ .Values.alerting.email.from | quote }}
+          smarthost: {{ .Values.alerting.email.smarthost | quote }}
+          authUsername: {{ .Values.alerting.email.username | quote }}
+          authPassword:
+            name: {{ .Values.smtpSecret.name | quote }}
+            key: {{ .Values.smtpSecret.key | default "SMTP_PASSWORD" | quote }}
+          sendResolved: {{ .Values.alerting.email.sendResolved }}
+{{- end }}

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -45,6 +45,11 @@ model:
     type: ClusterIP
     port: 8081
 
+smtpSecret:
+  create: false
+  name: alertmanager-smtp
+  smtpPassword: ""
+
 ingress:
   enabled: false
   className: ""

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -63,7 +63,7 @@ alerting:
   enabled: true
   configName: email-config
   email:
-    to: "solarct1@gmail.com" # change to your email
+    to: "changeme@please.com" # change to your email
     from: "doda.team4.alerts@gmail.com"
     smarthost: "smtp.gmail.com:587"
     username: "doda.team4.alerts@gmail.com"

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -49,6 +49,7 @@ smtpSecret:
   create: false
   name: alertmanager-smtp
   smtpPassword: ""
+  key: SMTP_PASSWORD
 
 ingress:
   enabled: false
@@ -58,42 +59,36 @@ ingress:
       path: /
   tls: []
 
+alerting:
+  enabled: true
+  configName: email-config
+  email:
+    to: "solarct1@gmail.com" # change to your email
+    from: "doda.team4.alerts@gmail.com"
+    smarthost: "smtp.gmail.com:587"
+    username: "doda.team4.alerts@gmail.com"
+    sendResolved: true
+  route:
+    groupBy: ["namespace", "alertname"]
+    groupWait: 5s
+    groupInterval: 1m
+    repeatInterval: 5m
+
 monitoring:
   enabled: true
   
   alertmanager:
     enabled: true # check if needed
     alertmanagerSpec:
-      secrets:
-        - alertmanager-smtp
+      alertmanagerConfigSelector:
+        matchLabels:
+          alertmanagerConfig: sms-app
+      alertmanagerConfigNamespaceSelector: {}
     config:
-      global:
-        resolve_timeout: 5m
-        smtp_smarthost: "smtp.gmail.com:587"
-        smtp_from: "doda.team4.alerts@gmail.com"
-        smtp_auth_username: "doda.team4.alerts@gmail.com"
-        smtp_auth_password_file: "/etc/alertmanager/secrets/alertmanager-smtp/SMTP_PASSWORD"
       route:
-        receiver: "email-alert"
-        group_by:
-          - namespace
-          - alertname
-        group_wait: 5s
-        group_interval: 1m
-        repeat_interval: 5m
-        routes:
-          - matchers:
-              - namespace="doda"
-            receiver: "email-alert"
-          - matchers:
-              - namespace!="doda"
-            receiver: "null"
+        receiver: "null"
       receivers:
         - name: "null"
-        - name: "email-alert"
-          email_configs:
-            - to: "replace@me.please"
-              send_resolved: true
 
   prometheusOperator:
     podAnnotations:


### PR DESCRIPTION
Because Assignment 3 required not only using a pre-deployed Secret, but also that 
"Please be aware that your manifests should not contain any sensitive information (e.g., SMTP passwords). Place them in a Secret that is automatically generated in a Helm chart." 
and since the rubric also required having at least one Secret template in the repository, I added a Secret template to the chart. 
By default, this Secret is not created or used by the application (secrets.create: false in values.yaml), so the deployment still works with a pre-deployed Secret provided externally. However, if desired, the chart can also generate the Secret by setting secrets.create: true and providing the password at install/upgrade time. To support this cleanly and avoid embedding credentials in manifests, I moved part of the Alertmanager configuration out of values.yaml into a Kubernetes CRD configuration (AlertmanagerConfig), which supports referencing credentials via secretKeyRef.